### PR TITLE
Extract timestamp from uuidv7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [v1.1.0](https://github.com/fboulnois/pg_uuidv7/compare/v1.0.2...v1.1.0) - 2023-07-22
+
+### Added
+
+* Bump extension version to 1.1.0
+* Extract timestamp from uuidv7
+
 ## [v1.0.2](https://github.com/fboulnois/pg_uuidv7/compare/v1.0.1...v1.0.2) - 2023-06-23
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,5 @@ COPY . /srv
 
 RUN make
 
-RUN tar -czvf pg_uuidv7.tar.gz pg_uuidv7--1.0.sql pg_uuidv7.control pg_uuidv7.so \
-  && sha256sum pg_uuidv7--1.0.sql pg_uuidv7.control pg_uuidv7.so pg_uuidv7.tar.gz > SHA256SUMS
+RUN tar -czvf pg_uuidv7.tar.gz pg_uuidv7--1.1.sql pg_uuidv7.control pg_uuidv7.so \
+  && sha256sum pg_uuidv7--1.1.sql pg_uuidv7.control pg_uuidv7.so pg_uuidv7.tar.gz > SHA256SUMS

--- a/META.json
+++ b/META.json
@@ -1,15 +1,15 @@
 {
   "name": "pg_uuidv7",
   "abstract": "Create UUIDv7 values in Postgres",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "maintainer": "fboulnois <fboulnois@users.noreply.github.com>",
   "license": "open_source",
   "provides": {
     "pg_uuidv7": {
       "abstract": "Create UUIDv7 values in Postgres",
-      "file": "pg_uuidv7--1.0.sql",
+      "file": "pg_uuidv7--1.1.sql",
       "docfile": "README.md",
-      "version": "1.0.2"
+      "version": "1.1.0"
     }
   },
   "resources": {

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 MODULES = pg_uuidv7
 EXTENSION = pg_uuidv7
-DATA = pg_uuidv7--1.0.sql
+DATA = pg_uuidv7--1.1.sql
 
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ can be created in parallel in a distributed system.
 1. Download the [latest `.tar.gz` release](https://github.com/fboulnois/pg_uuidv7/releases)
 and extract it to a temporary directory
 2. Copy `pg_uuidv7.so` into the Postgres module directory
-3. Copy `pg_uuidv7.control` and `pg_uuidv7--1.0.sql` into the Postgres extension
+3. Copy `pg_uuidv7.control` and `pg_uuidv7--1.1.sql` into the Postgres extension
 directory
 4. Add `pg_uuidv7` to the `shared_preload_libraries` setting in `postgresql.conf`
 5. Enable the extension in the database using `CREATE EXTENSION pg_uuidv7;`
@@ -39,11 +39,11 @@ directory
 ```sh
 # example shell script to install pg_uuidv7
 cd "$(mktemp -d)"
-curl -LO "https://github.com/fboulnois/pg_uuidv7/releases/download/v1.0.2/{pg_uuidv7.tar.gz,SHA256SUMS}"
+curl -LO "https://github.com/fboulnois/pg_uuidv7/releases/download/v1.1.0/{pg_uuidv7.tar.gz,SHA256SUMS}"
 tar xf pg_uuidv7.tar.gz
 sha256sum -c SHA256SUMS
 cp pg_uuidv7.so "$(pg_config --pkglibdir)"
-cp pg_uuidv7--1.0.sql pg_uuidv7.control "$(pg_config --sharedir)/extension"
+cp pg_uuidv7--1.1.sql pg_uuidv7.control "$(pg_config --sharedir)/extension"
 pg_conftool set shared_preload_libraries "pg_uuidv7"
 psql -c "CREATE EXTENSION pg_uuidv7;"
 ```

--- a/pg_uuidv7--1.1.sql
+++ b/pg_uuidv7--1.1.sql
@@ -1,0 +1,14 @@
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use '''CREATE EXTENSION "pg_uuidv7"''' to load this file. \quit
+
+-- 48 bits for ms since unix epoch (rollover in 10899), 74 bits of randomness
+CREATE FUNCTION uuid_generate_v7()
+RETURNS uuid
+AS 'MODULE_PATHNAME', 'uuid_generate_v7'
+VOLATILE STRICT LANGUAGE C PARALLEL SAFE;
+
+-- extract the timestamp from a v7 uuid
+CREATE FUNCTION uuid_v7_to_timestamptz(uuid)
+RETURNS timestamptz
+AS 'MODULE_PATHNAME', 'uuid_v7_to_timestamptz'
+VOLATILE STRICT LANGUAGE C PARALLEL SAFE;

--- a/pg_uuidv7.control
+++ b/pg_uuidv7.control
@@ -1,4 +1,4 @@
 comment = 'pg_uuidv7: create UUIDv7 values in postgres'
-default_version = '1.0'
+default_version = '1.1'
 module_pathname = '$libdir/pg_uuidv7'
 relocatable = true


### PR DESCRIPTION
Add a function to extract the timestamp from uuidv7 and bump the extension to 1.1.0.

Resolves #6 