### PR TITLE
Simplify timestamp extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v1.1.1](https://github.com/fboulnois/pg_uuidv7/compare/v1.1.0...v1.1.1) - 2023-07-23
+
+### Changed
+
+* Simplify timestamp extraction
+
 ## [v1.1.0](https://github.com/fboulnois/pg_uuidv7/compare/v1.0.2...v1.1.0) - 2023-07-22
 
 ### Added

--- a/META.json
+++ b/META.json
@@ -1,7 +1,7 @@
 {
   "name": "pg_uuidv7",
   "abstract": "Create UUIDv7 values in Postgres",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "maintainer": "fboulnois <fboulnois@users.noreply.github.com>",
   "license": "open_source",
   "provides": {
@@ -9,7 +9,7 @@
       "abstract": "Create UUIDv7 values in Postgres",
       "file": "pg_uuidv7--1.1.sql",
       "docfile": "README.md",
-      "version": "1.1.0"
+      "version": "1.1.1"
     }
   },
   "resources": {

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ directory
 ```sh
 # example shell script to install pg_uuidv7
 cd "$(mktemp -d)"
-curl -LO "https://github.com/fboulnois/pg_uuidv7/releases/download/v1.1.0/{pg_uuidv7.tar.gz,SHA256SUMS}"
+curl -LO "https://github.com/fboulnois/pg_uuidv7/releases/download/v1.1.1/{pg_uuidv7.tar.gz,SHA256SUMS}"
 tar xf pg_uuidv7.tar.gz
 sha256sum -c SHA256SUMS
 cp pg_uuidv7.so "$(pg_config --pkglibdir)"

--- a/README.md
+++ b/README.md
@@ -15,8 +15,18 @@ SELECT uuid_generate_v7();
 (1 row)
 ```
 
-This extension is nearly as fast as the native `gen_random_uuid()` function.
-See the [benchmarks](BENCHMARKS.md) for more details.
+The timestamp component of these UUIDs can also be extracted:
+
+```
+SELECT uuid_v7_to_timestamptz('018570bb-4a7d-7c7e-8df4-6d47afd8c8fc');
+   uuid_v7_to_timestamptz
+----------------------------
+ 2023-01-02 04:26:40.637+00
+(1 row)
+```
+
+`uuid_generate_v7()` is nearly as fast as the native `gen_random_uuid()`
+function. See the [benchmarks](BENCHMARKS.md) for more details.
 
 ## Background
 

--- a/pg_uuidv7.c
+++ b/pg_uuidv7.c
@@ -8,9 +8,9 @@
 #include <time.h>
 
 /*
- * Number of milliseconds between unix and postgres epoch
+ * Number of microseconds between unix and postgres epoch
  */
-#define EPOCH_DIFF_MS ((POSTGRES_EPOCH_JDATE - UNIX_EPOCH_JDATE) * USECS_PER_DAY / 1000)
+#define EPOCH_DIFF_USECS ((POSTGRES_EPOCH_JDATE - UNIX_EPOCH_JDATE) * USECS_PER_DAY)
 
 PG_MODULE_MAGIC;
 
@@ -54,11 +54,11 @@ PG_FUNCTION_INFO_V1(uuid_v7_to_timestamptz);
 Datum uuid_v7_to_timestamptz(PG_FUNCTION_ARGS)
 {
 	pg_uuid_t *uuid = PG_GETARG_UUID_P(0);
+	uint64_t ts;
 
-	uint64_t tms;
-	memcpy(&tms, &uuid->data[0], 6);
-	tms = pg_ntoh64(tms) >> 16;
-	tms = (tms - EPOCH_DIFF_MS) * 1000;
+	memcpy(&ts, &uuid->data[0], 6);
+	ts = pg_ntoh64(ts) >> 16;
+	ts = 1000 * ts - EPOCH_DIFF_USECS;
 
-	PG_RETURN_TIMESTAMPTZ(tms);
+	PG_RETURN_TIMESTAMPTZ(ts);
 }


### PR DESCRIPTION
Follow up to #7:

* Simplify the timestamp extraction function
* Include section in README.md on extracting timestamp
* Bump the extension to 1.1.1