### PR TITLE
Dockerfile improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 
-## [v1.3.0](https://github.com/fboulnois/pg_uuidv7/compare/v1.2.0...v1.3.0) - 2023-09-18
+## [v1.4.0](https://github.com/fboulnois/pg_uuidv7/compare/v1.3.0...v1.4.0) - 2023-11-28
+
+### Added
+
+* Bump extension metadata to 1.4.0
+* Run postgres with pg_uuidv7 extension
+
+### Changed
+
+* Move sql to top level to simplify install
+
+## [v1.3.0](https://github.com/fboulnois/pg_uuidv7/compare/v1.2.0...v1.3.0) - 2023-09-19
 
 ### Added
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,10 @@ COPY . /srv
 
 RUN for v in `seq 13 16`; do pg_buildext build-$v $v; done
 
-RUN cp sql/pg_uuidv7--1.3.sql . && TARGETS=$(find * -name pg_uuidv7.so) \
-  && tar -czvf pg_uuidv7.tar.gz $TARGETS pg_uuidv7--1.3.sql pg_uuidv7.control \
-  && sha256sum pg_uuidv7.tar.gz $TARGETS pg_uuidv7--1.3.sql pg_uuidv7.control > SHA256SUMS
+RUN cp sql/pg_uuidv7--1.4.sql . && TARGETS=$(find * -name pg_uuidv7.so) \
+  && tar -czvf pg_uuidv7.tar.gz $TARGETS pg_uuidv7--1.4.sql pg_uuidv7.control \
+  && sha256sum pg_uuidv7.tar.gz $TARGETS pg_uuidv7--1.4.sql pg_uuidv7.control > SHA256SUMS
 
 RUN cp ${PG_MAJOR}/pg_uuidv7.so /usr/lib/postgresql/${PG_MAJOR}/lib \
   && cp pg_uuidv7.control /usr/share/postgresql/${PG_MAJOR}/extension \
-  && cp pg_uuidv7--1.3.sql /usr/share/postgresql/${PG_MAJOR}/extension
+  && cp pg_uuidv7--1.4.sql /usr/share/postgresql/${PG_MAJOR}/extension

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,6 @@ COPY . /srv
 
 RUN for v in `seq 13 16`; do pg_buildext build-$v $v; done
 
-RUN TARGETS=$(find * -name pg_uuidv7.so) \
-  && tar -czvf pg_uuidv7.tar.gz $TARGETS sql/pg_uuidv7--1.3.sql pg_uuidv7.control \
-  && sha256sum pg_uuidv7.tar.gz $TARGETS sql/pg_uuidv7--1.3.sql pg_uuidv7.control > SHA256SUMS
+RUN cp sql/pg_uuidv7--1.3.sql . && TARGETS=$(find * -name pg_uuidv7.so) \
+  && tar -czvf pg_uuidv7.tar.gz $TARGETS pg_uuidv7--1.3.sql pg_uuidv7.control \
+  && sha256sum pg_uuidv7.tar.gz $TARGETS pg_uuidv7--1.3.sql pg_uuidv7.control > SHA256SUMS

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,3 +11,7 @@ RUN for v in `seq 13 16`; do pg_buildext build-$v $v; done
 RUN cp sql/pg_uuidv7--1.3.sql . && TARGETS=$(find * -name pg_uuidv7.so) \
   && tar -czvf pg_uuidv7.tar.gz $TARGETS pg_uuidv7--1.3.sql pg_uuidv7.control \
   && sha256sum pg_uuidv7.tar.gz $TARGETS pg_uuidv7--1.3.sql pg_uuidv7.control > SHA256SUMS
+
+RUN cp ${PG_MAJOR}/pg_uuidv7.so /usr/lib/postgresql/${PG_MAJOR}/lib \
+  && cp pg_uuidv7.control /usr/share/postgresql/${PG_MAJOR}/extension \
+  && cp pg_uuidv7--1.3.sql /usr/share/postgresql/${PG_MAJOR}/extension

--- a/META.json
+++ b/META.json
@@ -1,15 +1,15 @@
 {
   "name": "pg_uuidv7",
   "abstract": "Create UUIDv7 values in Postgres",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "maintainer": "fboulnois <fboulnois@users.noreply.github.com>",
   "license": "open_source",
   "provides": {
     "pg_uuidv7": {
       "abstract": "Create UUIDv7 values in Postgres",
-      "file": "sql/pg_uuidv7--1.3.sql",
+      "file": "sql/pg_uuidv7--1.4.sql",
       "docfile": "README.md",
-      "version": "1.3.0"
+      "version": "1.4.0"
     }
   },
   "resources": {

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 MODULES = pg_uuidv7
 EXTENSION = pg_uuidv7
-DATA = sql/pg_uuidv7--1.3.sql
+DATA = sql/pg_uuidv7--1.4.sql
 
 TESTS = $(wildcard test/sql/*.sql)
 REGRESS = $(patsubst test/sql/%.sql,%,$(TESTS))

--- a/README.md
+++ b/README.md
@@ -59,19 +59,19 @@ can be created in parallel in a distributed system.
 and extract it to a temporary directory
 2. Copy `pg_uuidv7.so` for your Postgres version into the Postgres module
 directory
-3. Copy `pg_uuidv7--1.3.sql` and `pg_uuidv7.control` into the Postgres extension
+3. Copy `pg_uuidv7--1.4.sql` and `pg_uuidv7.control` into the Postgres extension
 directory
 4. Enable the extension in the database using `CREATE EXTENSION pg_uuidv7;`
 
 ```sh
 # example shell script to install pg_uuidv7
 cd "$(mktemp -d)"
-curl -LO "https://github.com/fboulnois/pg_uuidv7/releases/download/v1.3.0/{pg_uuidv7.tar.gz,SHA256SUMS}"
+curl -LO "https://github.com/fboulnois/pg_uuidv7/releases/download/v1.4.0/{pg_uuidv7.tar.gz,SHA256SUMS}"
 tar xf pg_uuidv7.tar.gz
 sha256sum -c SHA256SUMS
 PG_MAJOR=$(pg_config --version | sed 's/^.* \([0-9]\{1,\}\).*$/\1/')
 cp "$PG_MAJOR/pg_uuidv7.so" "$(pg_config --pkglibdir)"
-cp pg_uuidv7--1.3.sql pg_uuidv7.control "$(pg_config --sharedir)/extension"
+cp pg_uuidv7--1.4.sql pg_uuidv7.control "$(pg_config --sharedir)/extension"
 psql -c "CREATE EXTENSION pg_uuidv7;"
 ```
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ tar xf pg_uuidv7.tar.gz
 sha256sum -c SHA256SUMS
 PG_MAJOR=$(pg_config --version | sed 's/^.* \([0-9]\{1,\}\).*$/\1/')
 cp "$PG_MAJOR/pg_uuidv7.so" "$(pg_config --pkglibdir)"
-cp sql/pg_uuidv7--1.3.sql pg_uuidv7.control "$(pg_config --sharedir)/extension"
+cp pg_uuidv7--1.3.sql pg_uuidv7.control "$(pg_config --sharedir)/extension"
 psql -c "CREATE EXTENSION pg_uuidv7;"
 ```
 

--- a/pg_uuidv7.control
+++ b/pg_uuidv7.control
@@ -1,4 +1,4 @@
 comment = 'pg_uuidv7: create UUIDv7 values in postgres'
-default_version = '1.3'
+default_version = '1.4'
 module_pathname = '$libdir/pg_uuidv7'
 relocatable = true

--- a/sql/pg_uuidv7--1.4.sql
+++ b/sql/pg_uuidv7--1.4.sql
@@ -1,0 +1,20 @@
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use '''CREATE EXTENSION "pg_uuidv7"''' to load this file. \quit
+
+-- 48 bits for ms since unix epoch (rollover in 10899), 74 bits of randomness
+CREATE FUNCTION uuid_generate_v7()
+RETURNS uuid
+AS 'MODULE_PATHNAME', 'uuid_generate_v7'
+VOLATILE STRICT LANGUAGE C PARALLEL SAFE;
+
+-- extract the timestamp from a v7 uuid
+CREATE FUNCTION uuid_v7_to_timestamptz(uuid)
+RETURNS timestamptz
+AS 'MODULE_PATHNAME', 'uuid_v7_to_timestamptz'
+VOLATILE STRICT LANGUAGE C PARALLEL SAFE;
+
+-- create a v7 uuid from a timestamp
+CREATE FUNCTION uuid_timestamptz_to_v7(timestamptz, zero bool = false)
+RETURNS uuid
+AS 'MODULE_PATHNAME', 'uuid_timestamptz_to_v7'
+VOLATILE STRICT LANGUAGE C PARALLEL SAFE;


### PR DESCRIPTION
Allows the `pg_uuidv7` container to be run directly as a regular Postgres instance with the `pg_uuidv7` extension ready to be loaded.

Resolves #17 , resolves #19 