### PR TITLE
Enable the UUIDV7 extension automatically in Docker Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,3 +24,6 @@ COPY --from=0 /srv/pg_uuidv7.tar.gz /srv/SHA256SUMS /srv
 COPY --from=0 /srv/${PG_MAJOR}/pg_uuidv7.so /usr/lib/postgresql/${PG_MAJOR}/lib
 COPY --from=0 /srv/pg_uuidv7.control /usr/share/postgresql/${PG_MAJOR}/extension
 COPY --from=0 /srv/pg_uuidv7--1.4.sql /usr/share/postgresql/${PG_MAJOR}/extension
+
+# install extension
+COPY ./sql/install-extensions.sql /docker-entrypoint-initdb.d

--- a/sql/install-extensions.sql
+++ b/sql/install-extensions.sql
@@ -1,0 +1,1 @@
+CREATE EXTENSION pg_uuidv7;


### PR DESCRIPTION
## What problems does this PR solves ?
The UUIDv7 extension needs to be manually enabled in Postgres using `CREATE EXTENSION pg_uuidv7;` after building the docker image.

## How does the PR solve this problem ?
This PR introduces an SQL file and a copy instruction on the Dockerfile as documented the **Initialization scripts** section of [DockerHub document](https://hub.docker.com/_/postgres) and the solutions mentioned in this [Stack Overflow post](https://stackoverflow.com/questions/55741735/docker-compose-and-postgres-extensions).

## Testing

### Building the container

```
docker build . --tag pg_uuidv7:16.2
[+] Building 168.2s (16/16) FINISHED                                                                                                     docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                     0.0s
 => => transferring dockerfile: 1.10kB                                                                                                                   0.0s
 => [internal] load metadata for docker.io/library/postgres:16                                                                                           2.8s
 => [internal] load .dockerignore                                                                                                                        0.0s
 => => transferring context: 2B                                                                                                                          0.0s
 => [internal] load build context                                                                                                                        0.1s
 => => transferring context: 14.91kB                                                                                                                     0.0s
 => [env-deploy 1/6] FROM docker.io/library/postgres:16@sha256:b88ca309fb656f7fc057ac4e6e74188ff1462a21c5527136b001390d6d2d4edb                         63.4s
 => => resolve docker.io/library/postgres:16@sha256:b88ca309fb656f7fc057ac4e6e74188ff1462a21c5527136b001390d6d2d4edb                                     0.0s
 => => sha256:59f5764b1f6d170ea07ca424965974024a14970ff826e9ffa3489c90dc040c24 29.16MB / 29.16MB                                                        22.6s
 => => sha256:a7354aa82f25b199783ffed4abb2934fb9c47dfa0497ebb931409e692aa13219 4.50MB / 4.50MB                                                           7.3s
 => => sha256:eae233f106f633adc0f551b7bfb6766149fddec54458520cafa6ac849ae1b00c 10.11kB / 10.11kB                                                         0.0s
 => => sha256:cf75f217268500ad7e781f5a11660d9aba2adb3e24951da3322be648ecb83ba3 1.17kB / 1.17kB                                                           2.8s
 => => sha256:b88ca309fb656f7fc057ac4e6e74188ff1462a21c5527136b001390d6d2d4edb 9.85kB / 9.85kB                                                           0.0s
 => => sha256:fe5bab5720ec73a61209666d67c6ce5a20861a0a8f58115dd594c85a900e958a 3.63kB / 3.63kB                                                           0.0s
 => => sha256:24f2f4668b6a9886b83b69eebdc95a30f1b480fdbf002085df25a5f498229a8f 1.38MB / 1.38MB                                                           6.1s
 => => sha256:ff84ef54facfbb2d9d933089f865eba3f4ad079a4f4205569d45595197bd9b79 8.07MB / 8.07MB                                                          23.2s
 => => sha256:2047c8c12c2d41c9ddd6515a74e5c3531a3e010ceddb4567eddca5eb0c4dc3fd 1.11MB / 1.11MB                                                           8.3s
 => => sha256:00a6174203e1a308d49571f7ec0103c06492df572e4b5cdedd5161748a7907cc 116B / 116B                                                               8.6s
 => => sha256:e99eea1c16ac89bed0ae2f94017e70c378193cfdb5f0a624453e316fd2107ade 3.15kB / 3.15kB                                                           8.9s
 => => sha256:780653660a823b69b5d64d66851de7a80cf3794f34f0f6a13b9c5b04decbffc8 107.32MB / 107.32MB                                                      61.3s
 => => extracting sha256:59f5764b1f6d170ea07ca424965974024a14970ff826e9ffa3489c90dc040c24                                                                1.0s
 => => sha256:093791b539204bace2fd16da4394ae263ee42579208a1897499c7c3aecabb19f 9.92kB / 9.92kB                                                          24.2s
 => => sha256:a716298a533fc01b451a4f19ec4d5a3e390e42d0d2a90af9d0e7782fdffe558a 129B / 129B                                                              23.9s
 => => extracting sha256:cf75f217268500ad7e781f5a11660d9aba2adb3e24951da3322be648ecb83ba3                                                                0.0s
 => => extracting sha256:a7354aa82f25b199783ffed4abb2934fb9c47dfa0497ebb931409e692aa13219                                                                0.1s
 => => extracting sha256:24f2f4668b6a9886b83b69eebdc95a30f1b480fdbf002085df25a5f498229a8f                                                                0.0s
 => => extracting sha256:ff84ef54facfbb2d9d933089f865eba3f4ad079a4f4205569d45595197bd9b79                                                                0.2s
 => => sha256:5fd3d570ab5b5d5c7b7ba91806c6e1cef67429fe9a286f999b170ef157bc9b36 171B / 171B                                                              24.3s
 => => extracting sha256:2047c8c12c2d41c9ddd6515a74e5c3531a3e010ceddb4567eddca5eb0c4dc3fd                                                                0.0s
 => => extracting sha256:00a6174203e1a308d49571f7ec0103c06492df572e4b5cdedd5161748a7907cc                                                                0.0s
 => => extracting sha256:e99eea1c16ac89bed0ae2f94017e70c378193cfdb5f0a624453e316fd2107ade                                                                0.0s
 => => sha256:b7036189a54a42b76a525632839443c704a1c783d35d8e3d29fb28789bad271b 5.42kB / 5.42kB                                                          24.5s
 => => sha256:a85fbb01d9ca9b9bc75fc547165be18a1d052af60c9bb856972c780cdce4e093 183B / 183B                                                              24.8s
 => => extracting sha256:780653660a823b69b5d64d66851de7a80cf3794f34f0f6a13b9c5b04decbffc8                                                                1.9s
 => => extracting sha256:093791b539204bace2fd16da4394ae263ee42579208a1897499c7c3aecabb19f                                                                0.0s
 => => extracting sha256:a716298a533fc01b451a4f19ec4d5a3e390e42d0d2a90af9d0e7782fdffe558a                                                                0.0s
 => => extracting sha256:5fd3d570ab5b5d5c7b7ba91806c6e1cef67429fe9a286f999b170ef157bc9b36                                                                0.0s
 => => extracting sha256:b7036189a54a42b76a525632839443c704a1c783d35d8e3d29fb28789bad271b                                                                0.0s
 => => extracting sha256:a85fbb01d9ca9b9bc75fc547165be18a1d052af60c9bb856972c780cdce4e093                                                                0.0s
 => [env-build 2/6] RUN apt-get update && apt-get -y upgrade   && apt-get install -y build-essential libpq-dev postgresql-server-dev-all               100.9s
 => [env-build 3/6] WORKDIR /srv                                                                                                                         0.0s
 => [env-build 4/6] COPY . /srv                                                                                                                          0.0s
 => [env-build 5/6] RUN for v in `seq 13 16`; do pg_buildext build-$v $v; done                                                                           0.5s
 => [env-build 6/6] RUN cp sql/pg_uuidv7--1.4.sql . && TARGETS=$(find * -name pg_uuidv7.so)   && tar -czvf pg_uuidv7.tar.gz $TARGETS pg_uuidv7--1.4.sql  0.4s
 => [env-deploy 2/6] COPY --from=0 /srv/pg_uuidv7.tar.gz /srv/SHA256SUMS /srv                                                                            0.0s
 => [env-deploy 3/6] COPY --from=0 /srv/16/pg_uuidv7.so /usr/lib/postgresql/16/lib                                                                       0.0s
 => [env-deploy 4/6] COPY --from=0 /srv/pg_uuidv7.control /usr/share/postgresql/16/extension                                                             0.0s
 => [env-deploy 5/6] COPY --from=0 /srv/pg_uuidv7--1.4.sql /usr/share/postgresql/16/extension                                                            0.0s
 => [env-deploy 6/6] COPY ./sql/install-extensions.sql /docker-entrypoint-initdb.d                                                                       0.0s
 => exporting to image                                                                                                                                   0.0s
 => => exporting layers                                                                                                                                  0.0s
 => => writing image sha256:356fa2316e412b445e6159b26eaa77cfd1dd5dfb548dc400e4de170fc73cf6cf                                                             0.0s
 => => naming to docker.io/library/pg_uuidv7:16.2
```
### Running the Container

```
pg_uuidv7 % docker run -d \                                  
--name local-postgres \
-e POSTGRES_PASSWORD=password \
-e PGDATA=/var/lib/postgresql/data/pgdata \
-v postgresdata:/var/lib/postgresql/data \
-p 5432:5432 \
pg_uuidv7:16.2
d4bab6c8cdf69a0c446826b00bd5966b64e37c8f30e437ef3e4596af0337bc23
```
### Testing out the function
<img width="1512" alt="image" src="https://github.com/fboulnois/pg_uuidv7/assets/109198085/0634f0bd-c965-46fa-a2ad-7ab4629d2184">

