### PR TITLE
Fix volatility of conversion functions

### DIFF
--- a/sql/pg_uuidv7--1.5.sql
+++ b/sql/pg_uuidv7--1.5.sql
@@ -11,10 +11,16 @@ VOLATILE STRICT LANGUAGE C PARALLEL SAFE;
 CREATE FUNCTION uuid_v7_to_timestamptz(uuid)
 RETURNS timestamptz
 AS 'MODULE_PATHNAME', 'uuid_v7_to_timestamptz'
-STABLE STRICT LANGUAGE C PARALLEL SAFE;
+IMMUTABLE STRICT LANGUAGE C PARALLEL SAFE;
 
 -- create a v7 uuid from a timestamp
 CREATE FUNCTION uuid_timestamptz_to_v7(timestamptz, zero bool = false)
+RETURNS uuid
+AS 'MODULE_PATHNAME', 'uuid_timestamptz_to_v7'
+IMMUTABLE STRICT LANGUAGE C PARALLEL SAFE;
+
+-- stable version to create a v7 uuid from a timestamp with timezone
+CREATE FUNCTION uuid_timestamptz_to_v7_stable(timestamptz, zero bool = false)
 RETURNS uuid
 AS 'MODULE_PATHNAME', 'uuid_timestamptz_to_v7'
 STABLE STRICT LANGUAGE C PARALLEL SAFE;


### PR DESCRIPTION
Function `uuid_v7_to_timestamptz` can be immutable since given an UUID it will return the same value for eternity regardless of timezone (the returned values will compare equal regardless of the timezone).

Function `uuid_timestamptz_to_v7` can be immutable since given a timestamp with a timezone it is ok to return the same random "filler" for each invocation since the random value cannot be reliabily used for anything and there is no requirement that each invocation have to return a different value.

This commit also adds a `uuid_timestamptz_to_v7_stable` for those cases where a stable value is required, that is, when executions in different queries have to return a different value.