### PR TITLE
Release v1.6.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
   pgxn-test:
     strategy:
       matrix:
-        pg: [16, 15, 14, 13]
+        pg: [17, 16, 15, 14, 13]
     runs-on: ubuntu-latest
     container: pgxn/pgxn-tools
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,7 +64,19 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
+          load: true
           push: true
           tags: |
             ghcr.io/${{ github.repository }}:latest
             ghcr.io/${{ github.repository }}:${{ env.BUILD_VERSION }}
+      - name: Run Docker image
+        run: docker run --name pg_uuidv7 ghcr.io/${{ github.repository }} /bin/sh
+      - name: Copy Docker container artifacts
+        run: docker cp pg_uuidv7:/srv/ ./
+      - name: Upload the latest artifacts to releases
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "srv/*"
+          makeLatest: true
+          name: ${{ env.GIT_TAG }}
+          tag: ${{ env.GIT_TAG }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [v1.6.0](https://github.com/fboulnois/pg_uuidv7/compare/v1.5.0...v1.6.0) - 2024-10-08
+
+### Added
+
+* Bump extension metadata to 1.6.0
+* Publish new versions to GitHub
+* Add Postgres 17 to test matrix
+* Update Dockerfile to use Postgres 17
+* Add tests for new timestamp conversions
+* Add timestamp conversion functions
+
 ## [v1.5.0](https://github.com/fboulnois/pg_uuidv7/compare/v1.4.1...v1.5.0) - 2024-03-21
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:16 AS env-build
+FROM postgres:17 AS env-build
 
 # install build dependencies
 RUN apt-get update && apt-get -y upgrade \
@@ -8,14 +8,14 @@ WORKDIR /srv
 COPY . /srv
 
 # build extension for all supported versions
-RUN for v in `seq 13 16`; do pg_buildext build-$v $v; done
+RUN for v in `seq 13 17`; do pg_buildext build-$v $v; done
 
 # create tarball and checksums
-RUN cp sql/pg_uuidv7--1.5.sql . && TARGETS=$(find * -name pg_uuidv7.so) \
-  && tar -czvf pg_uuidv7.tar.gz $TARGETS pg_uuidv7--1.5.sql pg_uuidv7.control \
-  && sha256sum pg_uuidv7.tar.gz $TARGETS pg_uuidv7--1.5.sql pg_uuidv7.control > SHA256SUMS
+RUN cp sql/pg_uuidv7--1.6.sql . && TARGETS=$(find * -name pg_uuidv7.so) \
+  && tar -czvf pg_uuidv7.tar.gz $TARGETS pg_uuidv7--1.6.sql pg_uuidv7.control \
+  && sha256sum pg_uuidv7.tar.gz $TARGETS pg_uuidv7--1.6.sql pg_uuidv7.control > SHA256SUMS
 
-FROM postgres:16 AS env-deploy
+FROM postgres:17 AS env-deploy
 
 # copy tarball and checksums
 COPY --from=0 /srv/pg_uuidv7.tar.gz /srv/SHA256SUMS /srv/
@@ -23,4 +23,4 @@ COPY --from=0 /srv/pg_uuidv7.tar.gz /srv/SHA256SUMS /srv/
 # add extension to postgres
 COPY --from=0 /srv/${PG_MAJOR}/pg_uuidv7.so /usr/lib/postgresql/${PG_MAJOR}/lib
 COPY --from=0 /srv/pg_uuidv7.control /usr/share/postgresql/${PG_MAJOR}/extension
-COPY --from=0 /srv/pg_uuidv7--1.5.sql /usr/share/postgresql/${PG_MAJOR}/extension
+COPY --from=0 /srv/pg_uuidv7--1.6.sql /usr/share/postgresql/${PG_MAJOR}/extension

--- a/META.json
+++ b/META.json
@@ -1,15 +1,15 @@
 {
   "name": "pg_uuidv7",
   "abstract": "Create UUIDv7 values in Postgres",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "maintainer": "fboulnois <fboulnois@users.noreply.github.com>",
   "license": "open_source",
   "provides": {
     "pg_uuidv7": {
       "abstract": "Create UUIDv7 values in Postgres",
-      "file": "sql/pg_uuidv7--1.5.sql",
+      "file": "sql/pg_uuidv7--1.6.sql",
       "docfile": "README.md",
-      "version": "1.5.0"
+      "version": "1.6.0"
     }
   },
   "resources": {

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 MODULES = pg_uuidv7
 EXTENSION = pg_uuidv7
-DATA = sql/pg_uuidv7--1.5.sql
+DATA = sql/pg_uuidv7--1.6.sql
 
 TESTS = $(wildcard test/sql/*.sql)
 REGRESS = $(patsubst test/sql/%.sql,%,$(TESTS))

--- a/README.md
+++ b/README.md
@@ -63,19 +63,19 @@ M1, Raspberry Pi, etc.) follow the [build instructions](#build) instead.
 and extract it to a temporary directory
 2. Copy `pg_uuidv7.so` for your Postgres version into the Postgres module
 directory
-3. Copy `pg_uuidv7--1.5.sql` and `pg_uuidv7.control` into the Postgres extension
+3. Copy `pg_uuidv7--1.6.sql` and `pg_uuidv7.control` into the Postgres extension
 directory
 4. Enable the extension in the database using `CREATE EXTENSION pg_uuidv7;`
 
 ```sh
 # example shell script to install pg_uuidv7
 cd "$(mktemp -d)"
-curl -LO "https://github.com/fboulnois/pg_uuidv7/releases/download/v1.5.0/{pg_uuidv7.tar.gz,SHA256SUMS}"
+curl -LO "https://github.com/fboulnois/pg_uuidv7/releases/download/v1.6.0/{pg_uuidv7.tar.gz,SHA256SUMS}"
 tar xf pg_uuidv7.tar.gz
 sha256sum -c SHA256SUMS
 PG_MAJOR=$(pg_config --version | sed 's/^.* \([0-9]\{1,\}\).*$/\1/')
 cp "$PG_MAJOR/pg_uuidv7.so" "$(pg_config --pkglibdir)"
-cp pg_uuidv7--1.5.sql pg_uuidv7.control "$(pg_config --sharedir)/extension"
+cp pg_uuidv7--1.6.sql pg_uuidv7.control "$(pg_config --sharedir)/extension"
 psql -c "CREATE EXTENSION pg_uuidv7;"
 ```
 
@@ -101,7 +101,7 @@ docker build . --tag pg_uuidv7
 A prebuilt x86_64 version of this image is on GitHub:
 
 ```sh
-docker pull ghcr.io/fboulnois/pg_uuidv7:1.5.0
+docker pull ghcr.io/fboulnois/pg_uuidv7:1.6.0
 ```
 
 The prebuilt image [is similar](https://github.com/fboulnois/pg_uuidv7/pull/29#issuecomment-1996102946)

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ can be created in parallel in a distributed system.
 ## Quickstart
 
 > [!IMPORTANT]
-> These instructions are for x86_64 Linux. On other architectures follow the
-[build instructions](#build) instead.
+> These instructions are for x86_64 Linux. On other architectures (e.g. Apple
+M1, Raspberry Pi, etc.) follow the [build instructions](#build) instead.
 
 1. Download the [latest `.tar.gz` release](https://github.com/fboulnois/pg_uuidv7/releases)
 and extract it to a temporary directory

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ against a specific version of Postgres and run the regression tests:
 docker build . --file test/Dockerfile --tag pgxn-test
 docker run --rm -it pgxn-test /bin/sh
 # once in container
-pg-start 16
+pg-start 17
 pg-build-test
 ```
 

--- a/pg_uuidv7.c
+++ b/pg_uuidv7.c
@@ -49,34 +49,43 @@ Datum uuid_generate_v7(PG_FUNCTION_ARGS)
 	PG_RETURN_UUID_P(uuid);
 }
 
-PG_FUNCTION_INFO_V1(uuid_v7_to_timestamptz);
-
-Datum uuid_v7_to_timestamptz(PG_FUNCTION_ARGS)
+static uint64_t uuid_v7_to_uint64(pg_uuid_t *uuid)
 {
-	pg_uuid_t *uuid = PG_GETARG_UUID_P(0);
 	uint64_t ts;
 
 	memcpy(&ts, &uuid->data[0], 6);
 	ts = pg_ntoh64(ts) >> 16;
 	ts = 1000 * ts - EPOCH_DIFF_USECS;
 
+	return ts;
+}
+
+PG_FUNCTION_INFO_V1(uuid_v7_to_timestamptz);
+
+Datum uuid_v7_to_timestamptz(PG_FUNCTION_ARGS)
+{
+	pg_uuid_t *uuid = PG_GETARG_UUID_P(0);
+	uint64_t ts = uuid_v7_to_uint64(uuid);
+
 	PG_RETURN_TIMESTAMPTZ(ts);
 }
 
-PG_FUNCTION_INFO_V1(uuid_timestamptz_to_v7);
+PG_FUNCTION_INFO_V1(uuid_v7_to_timestamp);
 
-Datum uuid_timestamptz_to_v7(PG_FUNCTION_ARGS)
+Datum uuid_v7_to_timestamp(PG_FUNCTION_ARGS)
+{
+	pg_uuid_t *uuid = PG_GETARG_UUID_P(0);
+	uint64_t ts = uuid_v7_to_uint64(uuid);
+
+	PG_RETURN_TIMESTAMP(ts);
+}
+
+static Datum uuid_uint64_to_v7(uint64_t ts, bool zero)
 {
 	pg_uuid_t *uuid = palloc(UUID_LEN);
-	bool zero = false;
 	uint64_t tms;
 
-	TimestampTz ts = PG_GETARG_TIMESTAMPTZ(0);
-
-	if (!PG_ARGISNULL(1))
-		zero = PG_GETARG_BOOL(1);
-
-	tms = ((uint64_t)ts + EPOCH_DIFF_USECS) / 1000;
+	tms = (ts + EPOCH_DIFF_USECS) / 1000;
 	tms = pg_hton64(tms << 16);
 	memcpy(&uuid->data[0], &tms, 6);
 
@@ -95,4 +104,30 @@ Datum uuid_timestamptz_to_v7(PG_FUNCTION_ARGS)
 	uuid->data[8] = (uuid->data[8] & 0x3f) | 0x80; /* 2 bit variant [10]   */
 
 	PG_RETURN_UUID_P(uuid);
+}
+
+PG_FUNCTION_INFO_V1(uuid_timestamptz_to_v7);
+
+Datum uuid_timestamptz_to_v7(PG_FUNCTION_ARGS)
+{
+	TimestampTz ts = PG_GETARG_TIMESTAMPTZ(0);
+	bool zero = false;
+
+	if (!PG_ARGISNULL(1))
+		zero = PG_GETARG_BOOL(1);
+
+	return uuid_uint64_to_v7(ts, zero);
+}
+
+PG_FUNCTION_INFO_V1(uuid_timestamp_to_v7);
+
+Datum uuid_timestamp_to_v7(PG_FUNCTION_ARGS)
+{
+	Timestamp ts = PG_GETARG_TIMESTAMP(0);
+	bool zero = false;
+
+	if (!PG_ARGISNULL(1))
+		zero = PG_GETARG_BOOL(1);
+
+	return uuid_uint64_to_v7(ts, zero);
 }

--- a/pg_uuidv7.control
+++ b/pg_uuidv7.control
@@ -1,4 +1,4 @@
 comment = 'pg_uuidv7: create UUIDv7 values in postgres'
-default_version = '1.5'
+default_version = '1.6'
 module_pathname = '$libdir/pg_uuidv7'
 relocatable = true

--- a/sql/pg_uuidv7--1.6.sql
+++ b/sql/pg_uuidv7--1.6.sql
@@ -1,0 +1,32 @@
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use '''CREATE EXTENSION "pg_uuidv7"''' to load this file. \quit
+
+-- 48 bits for ms since unix epoch (rollover in 10899), 74 bits of randomness
+CREATE FUNCTION uuid_generate_v7()
+RETURNS uuid
+AS 'MODULE_PATHNAME', 'uuid_generate_v7'
+VOLATILE STRICT LANGUAGE C PARALLEL SAFE;
+
+-- extract the timestamptz from a v7 uuid
+CREATE FUNCTION uuid_v7_to_timestamptz(uuid)
+RETURNS timestamptz
+AS 'MODULE_PATHNAME', 'uuid_v7_to_timestamptz'
+STABLE STRICT LANGUAGE C PARALLEL SAFE;
+
+-- create a v7 uuid from a timestamptz
+CREATE FUNCTION uuid_timestamptz_to_v7(timestamptz, zero bool = false)
+RETURNS uuid
+AS 'MODULE_PATHNAME', 'uuid_timestamptz_to_v7'
+STABLE STRICT LANGUAGE C PARALLEL SAFE;
+
+-- extract the timestamp from a v7 uuid
+CREATE FUNCTION uuid_v7_to_timestamp(uuid)
+RETURNS timestamp
+AS 'MODULE_PATHNAME', 'uuid_v7_to_timestamp'
+STABLE STRICT LANGUAGE C PARALLEL SAFE;
+
+-- create a v7 uuid from a timestamp
+CREATE FUNCTION uuid_timestamp_to_v7(timestamp, zero bool = false)
+RETURNS uuid
+AS 'MODULE_PATHNAME', 'uuid_timestamp_to_v7'
+STABLE STRICT LANGUAGE C PARALLEL SAFE;

--- a/test/expected/005_uuid_v7_to_timestamp.out
+++ b/test/expected/005_uuid_v7_to_timestamp.out
@@ -1,0 +1,10 @@
+-- set up variables for testing
+\set uuidv7 '018570bb-4a7d-7000-8000-000000000000'
+\set uuidts '2023-01-02 04:26:40.637'
+-- test converting a uuid to a timestamp
+SELECT uuid_v7_to_timestamp(:'uuidv7') = :'uuidts';
+ ?column? 
+----------
+ t
+(1 row)
+

--- a/test/expected/006_uuid_timestamp_to_v7.out
+++ b/test/expected/006_uuid_timestamp_to_v7.out
@@ -1,0 +1,17 @@
+-- set up variables for testing
+\set uuidv7 '018570bb-4a7d-7000-8000-000000000000'
+\set uuidts '2023-01-02 04:26:40.637'
+-- test converting a timestamp to a uuid
+SELECT uuid_timestamp_to_v7(:'uuidts') > :'uuidv7';
+ ?column? 
+----------
+ t
+(1 row)
+
+-- test converting a timestamp to a uuid and zero out the random bits
+SELECT uuid_timestamp_to_v7(:'uuidts', true) = :'uuidv7';
+ ?column? 
+----------
+ t
+(1 row)
+

--- a/test/sql/005_uuid_v7_to_timestamp.sql
+++ b/test/sql/005_uuid_v7_to_timestamp.sql
@@ -1,0 +1,6 @@
+-- set up variables for testing
+\set uuidv7 '018570bb-4a7d-7000-8000-000000000000'
+\set uuidts '2023-01-02 04:26:40.637'
+
+-- test converting a uuid to a timestamp
+SELECT uuid_v7_to_timestamp(:'uuidv7') = :'uuidts';

--- a/test/sql/006_uuid_timestamp_to_v7.sql
+++ b/test/sql/006_uuid_timestamp_to_v7.sql
@@ -1,0 +1,9 @@
+-- set up variables for testing
+\set uuidv7 '018570bb-4a7d-7000-8000-000000000000'
+\set uuidts '2023-01-02 04:26:40.637'
+
+-- test converting a timestamp to a uuid
+SELECT uuid_timestamp_to_v7(:'uuidts') > :'uuidv7';
+
+-- test converting a timestamp to a uuid and zero out the random bits
+SELECT uuid_timestamp_to_v7(:'uuidts', true) = :'uuidv7';


### PR DESCRIPTION
Release version 1.6.0 with a few improvements:

* Support conversion to and from regular timestamps, resolves #36
* Support Postgres 17, resolves #37, resolves #38
* Automatically publish new versions to GitHub
