### PR TITLE
chore: Rebuild when `PG_CONFIG` is from new major version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.built-with-pg-*

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,14 @@ TESTS = $(wildcard test/sql/*.sql)
 REGRESS = $(patsubst test/sql/%.sql,%,$(TESTS))
 REGRESS_OPTS = --inputdir=test
 
-PG_CONFIG = pg_config
+PG_CONFIG ?= pg_config
+PG_VERSION_MAJOR := $(shell $(PG_CONFIG) --version | sed -E 's/^PostgreSQL ([0-9]{2}).*$$/\1/')
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
+
+.PHONY: FORCE
+$(EXTENSION).bc: .built-with-pg-$(PG_VERSION_MAJOR)
+.built-with-pg-$(PG_VERSION_MAJOR): FORCE
+	if [ -f $@ ]; then echo "Still with Pg $(PG_VERSION_MAJOR)."; else touch $@; fi
+.NOTINTERMEDIATE: .built-with-pg-$(PG_VERSION_MAJOR)
+EXTRA_CLEAN = .built-with-pg-$(PG_VERSION_MAJOR)


### PR DESCRIPTION
This commit makes it so that the object files are rebuild when the major version returned by `pg_config --version` changes between `make` invocations.